### PR TITLE
Add custom wallpapers support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,5 @@
+import com.android.build.OutputFile
+import groovy.json.JsonOutput
 import net.waterfox.android.gradle.tasks.ApkSizeTask
 
 plugins {
@@ -13,8 +15,6 @@ apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 apply plugin: 'androidx.benchmark'
 
 
-import com.android.build.OutputFile
-import groovy.json.JsonOutput
 import org.gradle.internal.logging.text.StyledTextOutput.Style
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 
@@ -330,11 +330,13 @@ dependencies {
     implementation Deps.kotlin_coroutines_android
     testImplementation Deps.kotlin_coroutines_test
     implementation Deps.androidx_appcompat
+    implementation Deps.androidx_activity_compose
     implementation Deps.androidx_constraintlayout
     implementation Deps.androidx_coordinatorlayout
     implementation Deps.google_accompanist_drawablepainter
     implementation Deps.google_accompanist_insets
     implementation Deps.google_accompanist_swiperefresh
+    implementation Deps.coil
 
     implementation Deps.sentry
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,5 @@
+import com.android.build.OutputFile
+import groovy.json.JsonOutput
 import net.waterfox.android.gradle.tasks.ApkSizeTask
 
 plugins {
@@ -13,8 +15,6 @@ apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 apply plugin: 'androidx.benchmark'
 
 
-import com.android.build.OutputFile
-import groovy.json.JsonOutput
 import org.gradle.internal.logging.text.StyledTextOutput.Style
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,3 @@
-import com.android.build.OutputFile
-import groovy.json.JsonOutput
 import net.waterfox.android.gradle.tasks.ApkSizeTask
 
 plugins {
@@ -15,6 +13,8 @@ apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 apply plugin: 'androidx.benchmark'
 
 
+import com.android.build.OutputFile
+import groovy.json.JsonOutput
 import org.gradle.internal.logging.text.StyledTextOutput.Style
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
 
     <!-- Needed to post notifications on devices with Android 13 and later-->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <application
         android:name=".WaterfoxApplication"
@@ -297,6 +298,7 @@
 
         <service
             android:name=".downloads.DownloadService"
+            android:foregroundServiceType="dataSync"
             android:exported="false" />
 
         <receiver

--- a/app/src/main/java/net/waterfox/android/WaterfoxApplication.kt
+++ b/app/src/main/java/net/waterfox/android/WaterfoxApplication.kt
@@ -127,7 +127,7 @@ open class WaterfoxApplication : LocaleAwareApplication(), Provider {
             val megazordSetup = finishSetupMegazord()
 
             setDayNightTheme()
-            components.strictMode.enableStrictMode(true)
+            components.strictMode.enableStrictMode(false)
             warmBrowsersCache()
 
             initializeWebExtensionSupport()

--- a/app/src/main/java/net/waterfox/android/WaterfoxApplication.kt
+++ b/app/src/main/java/net/waterfox/android/WaterfoxApplication.kt
@@ -127,7 +127,7 @@ open class WaterfoxApplication : LocaleAwareApplication(), Provider {
             val megazordSetup = finishSetupMegazord()
 
             setDayNightTheme()
-            components.strictMode.enableStrictMode(false)
+            components.strictMode.enableStrictMode(true)
             warmBrowsersCache()
 
             initializeWebExtensionSupport()

--- a/app/src/main/java/net/waterfox/android/home/HomeFragment.kt
+++ b/app/src/main/java/net/waterfox/android/home/HomeFragment.kt
@@ -40,9 +40,8 @@ import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import mozilla.components.browser.menu.view.MenuButton
 import mozilla.components.browser.state.selector.findTab
@@ -62,11 +61,8 @@ import mozilla.components.feature.top.sites.TopSitesFrecencyConfig
 import mozilla.components.feature.top.sites.TopSitesProviderConfig
 import mozilla.components.lib.state.ext.consumeFlow
 import mozilla.components.lib.state.ext.consumeFrom
-import mozilla.components.lib.state.ext.flow
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.support.ktx.android.content.res.resolveAttribute
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.distinctUntilChangedBy
 import net.waterfox.android.HomeActivity
 import net.waterfox.android.R
 import net.waterfox.android.browser.BrowserAnimator.Companion.getToolbarNavOptions
@@ -899,7 +895,8 @@ class HomeFragment : Fragment() {
     private fun applyWallpaper(wallpaperName: String, orientationChange: Boolean) {
         when {
             !shouldEnableWallpaper() ||
-                    (wallpaperName == lastAppliedWallpaperName && !orientationChange) -> return
+                    (wallpaperName == lastAppliedWallpaperName && !orientationChange
+                            && wallpaperName != Wallpaper.Custom.name) -> return
 
             wallpaperName == Wallpaper.Default.name -> {
                 binding.wallpaperImageView.isVisible = false
@@ -909,9 +906,7 @@ class HomeFragment : Fragment() {
             else -> {
                 runBlockingIncrement {
                     with(requireComponents.wallpaperManager) {
-                        val bitmap = currentWallpaper.load(requireContext())
-                            ?: return@runBlockingIncrement
-                        bitmap.scaleBitmapToBottomOfView(binding.wallpaperImageView)
+                        currentWallpaper.set(binding.wallpaperImageView)
                     }
                     binding.wallpaperImageView.isVisible = true
                     lastAppliedWallpaperName = wallpaperName

--- a/app/src/main/java/net/waterfox/android/settings/wallpaper/CustomWallpaper.kt
+++ b/app/src/main/java/net/waterfox/android/settings/wallpaper/CustomWallpaper.kt
@@ -1,0 +1,249 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package net.waterfox.android.settings.wallpaper
+
+import android.content.res.Configuration
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material.Switch
+import androidx.compose.material.SwitchDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import net.waterfox.android.R
+import net.waterfox.android.compose.button.Button
+import net.waterfox.android.compose.ext.dashedBorder
+import net.waterfox.android.theme.Theme
+import net.waterfox.android.theme.WaterfoxTheme
+
+@Composable
+fun CustomWallpaper(
+    currentPortraitImageUri: Uri?,
+    currentLandscapeImageUri: Uri?,
+    onSaveClick: (Uri?, Uri?, Boolean) -> Unit,
+) {
+    val configuration = LocalConfiguration.current
+    var portraitImageUri by rememberSaveable {
+        mutableStateOf(currentPortraitImageUri)
+    }
+    var landscapeImageUri by rememberSaveable {
+        mutableStateOf(currentLandscapeImageUri)
+    }
+    var useSingleImage by rememberSaveable {
+        mutableStateOf(false)
+    }
+    val portraitImageUriLauncher =
+        rememberLauncherForActivityResult(PickVisualMedia()) {
+            portraitImageUri = it
+        }
+    val landscapeImageUriLauncher =
+        rememberLauncherForActivityResult(PickVisualMedia()) {
+            landscapeImageUri = it
+        }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Top,
+    ) {
+        if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            Row(
+                modifier = Modifier.weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                CustomWallpaperContent(
+                    portraitImageUri = portraitImageUri,
+                    landscapeImageUri = landscapeImageUri,
+                    useSingleImage = useSingleImage,
+                    onSelectPortraitClick = {
+                        portraitImageUriLauncher.launch(
+                            PickVisualMediaRequest(PickVisualMedia.ImageOnly)
+                        )
+                    },
+                    onSelectLandscapeClick = {
+                        landscapeImageUriLauncher.launch(
+                            PickVisualMediaRequest(PickVisualMedia.ImageOnly)
+                        )
+                    },
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        } else {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                CustomWallpaperContent(
+                    portraitImageUri = portraitImageUri,
+                    landscapeImageUri = landscapeImageUri,
+                    useSingleImage = useSingleImage,
+                    onSelectPortraitClick = {
+                        portraitImageUriLauncher.launch(
+                            PickVisualMediaRequest(PickVisualMedia.ImageOnly)
+                        )
+                    },
+                    onSelectLandscapeClick = {
+                        landscapeImageUriLauncher.launch(
+                            PickVisualMediaRequest(PickVisualMedia.ImageOnly)
+                        )
+                    },
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+        SingleImageSwitch(
+            checked = useSingleImage,
+            onCheckedChange = { useSingleImage = it },
+        )
+        Button(
+            text = stringResource(id = R.string.wallpaper_save_custom),
+            textColor = WaterfoxTheme.colors.textActionPrimary,
+            backgroundColor = WaterfoxTheme.colors.actionPrimary,
+            tint = WaterfoxTheme.colors.iconActionPrimary,
+        ) {
+            onSaveClick(portraitImageUri, landscapeImageUri, useSingleImage)
+        }
+    }
+}
+
+@Composable
+fun CustomWallpaperContent(
+    portraitImageUri: Uri?,
+    landscapeImageUri: Uri?,
+    useSingleImage: Boolean,
+    onSelectPortraitClick: () -> Unit,
+    onSelectLandscapeClick: () -> Unit,
+    modifier: Modifier,
+) {
+    WallpaperSelector(
+        imageUri = portraitImageUri,
+        text = stringResource(id = R.string.wallpaper_select_portrait),
+        modifier = modifier,
+        action = {
+            onSelectPortraitClick()
+        },
+    )
+    if (!useSingleImage) {
+        WallpaperSelector(
+            imageUri = landscapeImageUri,
+            text = stringResource(id = R.string.wallpaper_select_landscape),
+            modifier = modifier,
+            action = {
+                onSelectLandscapeClick()
+            },
+        )
+    }
+}
+
+@Preview(device = "spec:width=411dp,height=891dp,orientation=portrait")
+@Preview(device = "spec:width=411dp,height=891dp,orientation=landscape")
+@Composable
+fun CustomWallpaperPreview() {
+    WaterfoxTheme(theme = Theme.getTheme()) {
+        CustomWallpaper(
+            currentPortraitImageUri = null,
+            currentLandscapeImageUri = null,
+            onSaveClick = { _, _, _ -> },
+        )
+    }
+}
+
+@Composable
+private fun WallpaperSelector(
+    imageUri: Uri?,
+    text: String,
+    modifier: Modifier = Modifier,
+    action: () -> Unit,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .dashedBorder(
+                    color = WaterfoxTheme.colors.borderPrimary,
+                    cornerRadius = 8.dp,
+                    dashHeight = 2.dp,
+                    dashWidth = 4.dp
+                ),
+        ) {
+            AsyncImage(
+                model = imageUri,
+                contentDescription = stringResource(id = R.string.wallpaper_image_content_description),
+                modifier = Modifier
+                    .padding(1.dp)
+                    .fillMaxSize(),
+            )
+        }
+        Button(
+            text = text,
+            textColor = WaterfoxTheme.colors.textActionSecondary,
+            backgroundColor = WaterfoxTheme.colors.actionSecondary,
+            tint = WaterfoxTheme.colors.iconActionSecondary,
+        ) {
+            action()
+        }
+    }
+}
+
+@Composable
+private fun SingleImageSwitch(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .padding(horizontal = 16.dp, vertical = 16.dp)
+            .fillMaxWidth()
+            .toggleable(
+                value = checked,
+                onValueChange = onCheckedChange,
+                role = Role.Switch,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = stringResource(id = R.string.wallpaper_use_single_image),
+            color = WaterfoxTheme.colors.textPrimary,
+            fontSize = 18.sp,
+            modifier = Modifier
+                .weight(0.8f),
+        )
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = WaterfoxTheme.colors.formSelected,
+                checkedTrackColor = WaterfoxTheme.colors.formSurface,
+                uncheckedTrackColor = WaterfoxTheme.colors.formSurface,
+            ),
+        )
+    }
+}

--- a/app/src/main/java/net/waterfox/android/settings/wallpaper/CustomWallpaperFragment.kt
+++ b/app/src/main/java/net/waterfox/android/settings/wallpaper/CustomWallpaperFragment.kt
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package net.waterfox.android.settings.wallpaper
+
+import android.net.Uri
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.navigation.findNavController
+import net.waterfox.android.R
+import net.waterfox.android.ext.requireComponents
+import net.waterfox.android.ext.showToolbar
+import net.waterfox.android.theme.WaterfoxTheme
+import net.waterfox.android.wallpapers.LANDSCAPE
+import net.waterfox.android.wallpapers.PORTRAIT
+import net.waterfox.android.wallpapers.Wallpaper
+
+class CustomWallpaperFragment : Fragment() {
+
+    private val wallpaperManager by lazy { requireComponents.wallpaperManager }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        val portraitImageUri = Uri.fromFile(
+            wallpaperManager.getWallpaperFile(requireContext(), PORTRAIT, Wallpaper.Custom.name),
+        )
+        val landscapeImageUri = Uri.fromFile(
+            wallpaperManager.getWallpaperFile(requireContext(), LANDSCAPE, Wallpaper.Custom.name),
+        )
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                WaterfoxTheme {
+                    CustomWallpaper(
+                        currentPortraitImageUri = portraitImageUri,
+                        currentLandscapeImageUri = landscapeImageUri,
+                        onSaveClick = { portraitImageUri, landscapeImageUri, useSingleImage ->
+                            wallpaperManager.applyCustomWallpaper(
+                                requireContext(),
+                                portraitImageUri,
+                                landscapeImageUri,
+                                useSingleImage,
+                            )
+                            findNavController().popBackStack()
+                        },
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        showToolbar(getString(R.string.customize_wallpapers))
+    }
+}

--- a/app/src/main/java/net/waterfox/android/settings/wallpaper/WallpaperSettingsFragment.kt
+++ b/app/src/main/java/net/waterfox/android/settings/wallpaper/WallpaperSettingsFragment.kt
@@ -24,13 +24,9 @@ import net.waterfox.android.wallpapers.Wallpaper
 import net.waterfox.android.wallpapers.WallpaperManager
 
 class WallpaperSettingsFragment : Fragment() {
-    private val wallpaperManager by lazy {
-        requireComponents.wallpaperManager
-    }
 
-    private val settings by lazy {
-        requireComponents.settings
-    }
+    private val wallpaperManager by lazy { requireComponents.wallpaperManager }
+    private val settings by lazy { requireComponents.settings }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -53,6 +49,11 @@ class WallpaperSettingsFragment : Fragment() {
                         onSelectWallpaper = { selectedWallpaper: Wallpaper ->
                             currentWallpaper = selectedWallpaper
                             wallpaperManager.currentWallpaper = selectedWallpaper
+                        },
+                        onSetCustomWallpaper = {
+                            findNavController().navigate(
+                                WallpaperSettingsFragmentDirections.actionWallpaperSettingsFragmentToCustomWallpaperFragment(),
+                            )
                         },
                         onViewWallpaper = { findNavController().navigate(R.id.homeFragment) },
                         tapLogoSwitchChecked = wallpapersSwitchedByLogo,

--- a/app/src/main/java/net/waterfox/android/wallpapers/Wallpaper.kt
+++ b/app/src/main/java/net/waterfox/android/wallpapers/Wallpaper.kt
@@ -24,6 +24,13 @@ sealed class Wallpaper {
     }
 
     /**
+     * The custom wallpaper set by a user.
+     */
+    object Custom : Wallpaper() {
+        override val name: String = "custom"
+    }
+
+    /**
      * If a user had previously selected a wallpaper, they are allowed to retain it even if
      * the wallpaper is otherwise expired. This type exists as a wrapper around that current
      * wallpaper.
@@ -95,5 +102,14 @@ sealed class Wallpaper {
          */
         fun getBaseLocalPath(orientation: String, theme: String, name: String): String =
             "wallpapers/$orientation/$theme/$name.png"
+
+        /**
+         * Defines the standard path at which a wallpaper resource is kept on disk.
+         *
+         * @param orientation One of landscape/portrait.
+         * @param name The name of the wallpaper.
+         */
+        fun getBaseLocalPath(orientation: String, name: String): String =
+            "wallpapers/$orientation/$name.png"
     }
 }

--- a/app/src/main/java/net/waterfox/android/wallpapers/WallpaperFileManager.kt
+++ b/app/src/main/java/net/waterfox/android/wallpapers/WallpaperFileManager.kt
@@ -4,6 +4,8 @@
 
 package net.waterfox.android.wallpapers
 
+import android.content.Context
+import android.net.Uri
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -51,6 +53,25 @@ class WallpaperFileManager(
         for (file in dir.walkTopDown()) {
             if (file.isDirectory || file.nameWithoutExtension in wallpapersToKeep) continue
             file.delete()
+        }
+    }
+
+    fun copyWallpaperImage(
+        context: Context,
+        orientation: String,
+        uri: Uri,
+    ) {
+        scope.launch {
+            val localFile = File(
+                context.filesDir,
+                Wallpaper.getBaseLocalPath(orientation, Wallpaper.Custom.name),
+            )
+            File(localFile.absolutePath.substringBeforeLast("/")).mkdirs()
+            context.contentResolver.openInputStream(uri).use { input ->
+                localFile.outputStream().use { output ->
+                    input?.copyTo(output)
+                }
+            }
         }
     }
 }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -671,7 +671,19 @@
     <fragment
         android:id="@+id/wallpaperSettingsFragment"
         android:name="net.waterfox.android.settings.wallpaper.WallpaperSettingsFragment"
-        android:label="@string/customize_wallpapers"/>
+        android:label="@string/customize_wallpapers">
+        <action
+            android:id="@+id/action_wallpaperSettingsFragment_to_customWallpaperFragment"
+            app:destination="@id/customWallpaperFragment"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right" />
+    </fragment>
+    <fragment
+        android:id="@+id/customWallpaperFragment"
+        android:name="net.waterfox.android.settings.wallpaper.CustomWallpaperFragment"
+        android:label="@string/customize_wallpapers" />
     <fragment
         android:id="@+id/sitePermissionsFragment"
         android:name="net.waterfox.android.settings.sitepermissions.SitePermissionsFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -441,6 +441,16 @@
     <!-- This is the accessibility content description for the wallpapers functionality. Users are
     able to tap on the app logo in the home screen and can switch to different wallpapers by tapping. -->
     <string name="wallpaper_logo_content_description">Waterfox logo - change the wallpaper, button</string>
+    <!-- Label for the button that opens system picker to select custom wallpaper image for portrait orientation -->
+    <string name="wallpaper_select_portrait">Select portrait</string>
+    <!-- Label for the button that opens system picker to select custom wallpaper image for landscape orientation -->
+    <string name="wallpaper_select_landscape">Select landscape</string>
+    <!-- Label for the button that saves the custom wallpaper -->
+    <string name="wallpaper_save_custom">Save</string>
+    <!-- Label for the switch that toggles using single image for both orientations -->
+    <string name="wallpaper_use_single_image">Use single image</string>
+    <!-- Content description for a wallpaper image -->
+    <string name="wallpaper_image_content_description">Wallpaper image</string>
 
     <!-- Add-on Installation from AMO-->
     <!-- Error displayed when user attempts to install an add-on from AMO (addons.mozilla.org) that is not supported -->

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -21,6 +21,7 @@ object Versions {
     const val androidx_compose_paging = "1.0.0-alpha20"
     const val androidx_compose_compiler = "1.4.8"
     const val androidx_appcompat = "1.6.1"
+    const val androidx_activity_compose = "1.8.2"
     const val androidx_benchmark = "1.0.0"
     const val androidx_biometric = "1.1.0"
     const val androidx_coordinator_layout = "1.1.0"
@@ -39,6 +40,7 @@ object Versions {
     const val androidx_datastore = "1.0.0"
     const val google_material = "1.2.1"
     const val accompanist_drawablepainter = "0.23.1"
+    const val coil = "2.5.0"
 
     const val mozilla_android_components = "122.0b9"
 
@@ -177,6 +179,7 @@ object Deps {
     const val androidx_biometric = "androidx.biometric:biometric:${Versions.androidx_biometric}"
     const val androidx_fragment = "androidx.fragment:fragment-ktx:${Versions.androidx_fragment}"
     const val androidx_appcompat = "androidx.appcompat:appcompat:${Versions.androidx_appcompat}"
+    const val androidx_activity_compose = "androidx.activity:activity-compose:${Versions.androidx_activity_compose}"
     const val androidx_coordinatorlayout = "androidx.coordinatorlayout:coordinatorlayout:${Versions.androidx_coordinator_layout}"
     const val androidx_constraintlayout = "androidx.constraintlayout:constraintlayout:${Versions.androidx_constraint_layout}"
     const val androidx_legacy = "androidx.legacy:legacy-support-v4:${Versions.androidx_legacy}"
@@ -204,6 +207,7 @@ object Deps {
         "com.google.accompanist:accompanist-insets:${Versions.accompanist_drawablepainter}"
     const val google_accompanist_swiperefresh =
         "com.google.accompanist:accompanist-swiperefresh:${Versions.accompanist_drawablepainter}"
+    const val coil = "io.coil-kt:coil-compose:${Versions.coil}"
 
     const val jna = "net.java.dev.jna:jna:${Versions.jna}@jar"
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -42,7 +42,7 @@ object Versions {
     const val accompanist_drawablepainter = "0.23.1"
     const val coil = "2.4.0"
 
-    const val mozilla_android_components = "122.0b9"
+    const val mozilla_android_components = "122.0"
 
     const val junit = "5.5.2"
     const val mockk = "1.13.8"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -40,7 +40,7 @@ object Versions {
     const val androidx_datastore = "1.0.0"
     const val google_material = "1.2.1"
     const val accompanist_drawablepainter = "0.23.1"
-    const val coil = "2.5.0"
+    const val coil = "2.4.0"
 
     const val mozilla_android_components = "122.0b9"
 


### PR DESCRIPTION
Add a new settings screen to set a custom home screen wallpaper. 
A user can pick the wallpaper from the file system. It's possible to use different images or a single image for portrait and landscape orientations. 