### PR TITLE
Fix downloading on Android 14

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
 
     <!-- Needed to post notifications on devices with Android 13 and later-->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <application
         android:name=".WaterfoxApplication"
@@ -297,6 +298,7 @@
 
         <service
             android:name=".downloads.DownloadService"
+            android:foregroundServiceType="dataSync"
             android:exported="false" />
 
         <receiver

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -40,7 +40,7 @@ object Versions {
     const val google_material = "1.2.1"
     const val accompanist_drawablepainter = "0.23.1"
 
-    const val mozilla_android_components = "122.0b9"
+    const val mozilla_android_components = "122.0"
 
     const val junit = "5.5.2"
     const val mockk = "1.13.8"


### PR DESCRIPTION
- add the download service foregrounds service type and new permission
- update android components to 122.0