### PR TITLE
Fix crash due to DiskReadViolation when set the custom wallpaper

### DIFF
--- a/app/src/main/java/net/waterfox/android/WaterfoxApplication.kt
+++ b/app/src/main/java/net/waterfox/android/WaterfoxApplication.kt
@@ -17,6 +17,8 @@ import androidx.core.content.getSystemService
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.work.Configuration.Builder
 import androidx.work.Configuration.Provider
+import coil.Coil
+import coil.ImageLoader
 import kotlinx.coroutines.*
 import mozilla.appservices.Megazord
 import mozilla.components.browser.state.action.SystemAction
@@ -111,6 +113,13 @@ open class WaterfoxApplication : LocaleAwareApplication(), Provider {
     open fun setupInMainProcessOnly() {
         beginSetupMegazord()
         ProfilerMarkerFactProcessor.create { components.core.engine.profiler }.register()
+
+        // This is a workaround for https://github.com/coil-kt/coil/issues/383
+        Coil.setImageLoader(
+            ImageLoader.Builder(this)
+                .addLastModifiedToFileCacheKey(false)
+                .build()
+        )
 
         run {
             // Make sure the engine is initialized and ready to use.

--- a/app/src/main/java/net/waterfox/android/wallpapers/WallpaperManager.kt
+++ b/app/src/main/java/net/waterfox/android/wallpapers/WallpaperManager.kt
@@ -298,19 +298,23 @@ class WallpaperManager(
             return equals(customWallpaper.name)
         }
 
-        fun getCustomWallpaperFile(context: Context): File {
+        fun getCustomWallpaperFile(context: Context): File? = Result.runCatching {
             val orientation = if (context.isLandscape()) LANDSCAPE else PORTRAIT
             val path = Wallpaper.getBaseLocalPath(orientation, Wallpaper.Custom.name)
-            val file = File(context.filesDir, path)
-            return if (file.exists()) {
-                file
-            } else {
-                File(
-                    context.filesDir,
-                    Wallpaper.getBaseLocalPath(PORTRAIT, Wallpaper.Custom.name),
-                )
+            runBlockingIncrement {
+                withContext(Dispatchers.IO) {
+                    val file = File(context.filesDir, path)
+                    if (file.exists()) {
+                        file
+                    } else {
+                        File(
+                            context.filesDir,
+                            Wallpaper.getBaseLocalPath(PORTRAIT, Wallpaper.Custom.name),
+                        )
+                    }
+                }
             }
-        }
+        }.getOrNull()
 
         private fun Context.isLandscape(): Boolean {
             return resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE


### PR DESCRIPTION
- check if the custom wallpaper files exist in the background thread
- configure Coil skip using a file's last modified attribute to avoid DiskReadViolation