### PR TITLE
ANDROID-3X: Add a unique ID for each record in history

### DIFF
--- a/app/src/main/java/net/waterfox/android/library/history/HistoryComposeView.kt
+++ b/app/src/main/java/net/waterfox/android/library/history/HistoryComposeView.kt
@@ -136,7 +136,7 @@ class HistoryComposeView @JvmOverloads constructor(
 
                         items(
                             count = historyList.itemCount,
-                            key = historyList.itemKey { it.position },
+                            key = historyList.itemKey { it.id },
                         ) { index ->
                             val history = historyList[index]
 

--- a/app/src/main/java/net/waterfox/android/library/history/HistoryFragmentStore.kt
+++ b/app/src/main/java/net/waterfox/android/library/history/HistoryFragmentStore.kt
@@ -13,11 +13,15 @@ import mozilla.components.lib.state.State
 import mozilla.components.lib.state.Store
 import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
 import net.waterfox.android.selection.SelectionHolder
+import java.util.UUID
 
 /**
  * Class representing a history entry.
+ *
+ * @property id Unique id generated to use as an item key
  */
 sealed class History : Parcelable {
+    val id: String = UUID.randomUUID().toString()
     abstract val position: Int
     abstract val title: String
     abstract val visitedAt: Long


### PR DESCRIPTION
Generate a unique ID for each history record to use in the compose paging as a key for lazy layout. 